### PR TITLE
Feat/espaço pratico/task 4 backend create register user usecase

### DIFF
--- a/espaco-pratico-api/src/application/dto/create-user.dto.ts
+++ b/espaco-pratico-api/src/application/dto/create-user.dto.ts
@@ -1,0 +1,5 @@
+export interface ICreateUserDTO {
+    fullName: string;
+    email: string;
+    password: string;
+}

--- a/espaco-pratico-api/src/application/use-cases/register-user/register-user.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/register-user/register-user.spec.ts
@@ -1,0 +1,177 @@
+import { RegisterUserUseCase } from "./register-user.use-case";
+import { IUserRepository } from "../../../domain/interfaces/repositories/user-repository.interface";
+import { User } from "../../../domain/entities/userEntity/user.entity";
+
+const mockUserData = {
+    fullName: "John Doe",
+    email: "johndoe@test.com",
+    password: "Securepassword123!",
+};
+
+const mockUser = {
+    _id: "mocked-generated-id",
+    _fullName: mockUserData.fullName,
+    _email: mockUserData.email,
+    _password: mockUserData.password,
+}
+
+const mockUserRepository: IUserRepository = {
+    createUser: jest.fn(),
+    findUserById: jest.fn(),
+    findUserByEmail: jest.fn(),
+    updateUser: jest.fn(),
+    deleteUser: jest.fn(),
+};
+
+const registerUserUseCase = new RegisterUserUseCase(mockUserRepository);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("Validate required fields", () => {
+
+    it("should not throw an error if all required fields are present", () => {
+        expect(() => registerUserUseCase.validateRequiredFields(mockUserData)).not.toThrow();
+    });
+
+    it("should throw an error if fullName is missing", () => {
+        const userData = {
+            ...mockUserData,
+            fullName: "",
+        }
+
+        expect(() => registerUserUseCase.validateRequiredFields(userData)).toThrow("All fields are required: fullName, email, and password.");
+    });
+
+    it("should throw an error if email is missing", () => {
+        const userData = {
+            ...mockUserData,
+            email: "",
+        }
+
+        expect(() => registerUserUseCase.validateRequiredFields(userData)).toThrow("All fields are required: fullName, email, and password.");
+    });
+
+    it("should throw an error if password is missing", () => {
+        const userData = {
+            ...mockUserData,
+            password: "",
+        }
+
+        expect(() => registerUserUseCase.validateRequiredFields(userData)).toThrow("All fields are required: fullName, email, and password.");
+    });
+});
+
+describe("Validate email does not exist", () => {
+    it("should not throw an error if email does not exist", async () => {
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(null);
+
+        await expect(registerUserUseCase.validateEmailDoesNotExist('email@notexist.com')).resolves.not.toThrow();
+
+        expect(mockUserRepository.findUserByEmail).toHaveBeenCalledWith('email@notexist.com');
+    });
+
+    it("should throw an error if email already exists", async () => {
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue({});
+
+        await expect(registerUserUseCase.validateEmailDoesNotExist(mockUserData.email)).rejects.toThrow("User with this email already exists.");
+
+        expect(mockUserRepository.findUserByEmail).toHaveBeenCalledWith('johndoe@test.com');
+    });
+})
+
+describe("Generate user ID", () => {
+    it("should generate a valid UUID", () => {
+        const userId = registerUserUseCase.generateUserId();
+
+        expect(typeof userId).toBe('string');
+        expect(userId).toHaveLength(36);
+        expect(userId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+
+    });
+
+    it("should generate unique IDs on multiple calls", () => {
+        const userId1 = registerUserUseCase.generateUserId();
+        const userId2 = registerUserUseCase.generateUserId();
+        const userId3 = registerUserUseCase.generateUserId();
+
+        expect(userId1).not.toBe(userId2);
+        expect(userId1).not.toBe(userId3);
+        expect(userId2).not.toBe(userId3);
+    })
+})
+
+describe("Execute use case", () => {
+    it("should call repository with correct user object when creating a user", async () => {
+        mockUserRepository.createUser = jest.fn().mockResolvedValue(
+            {...mockUserData, 
+                id: 'mocked-generated-id'
+            });
+
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(null);
+
+        const result = await registerUserUseCase.execute(mockUserData);
+
+        expect(mockUserRepository.createUser).toHaveBeenCalledWith(expect.objectContaining({
+            ...mockUser, 
+            _id: expect.any(String)
+        }));
+    });
+
+    it("should return the created user object", async () => {
+        mockUserRepository.createUser = jest.fn().mockResolvedValue(mockUser);
+
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(null);
+
+        const result = await registerUserUseCase.execute(mockUserData);
+
+        expect(result).toEqual(mockUser);
+    });
+
+    it("should generate a user ID when creating a user", async () => {
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(null);
+        mockUserRepository.createUser = jest.fn().mockResolvedValue({...mockUserData, id: 'some-id'});
+        
+        const spy = jest.spyOn(registerUserUseCase, 'generateUserId');
+        
+        await registerUserUseCase.execute(mockUserData);
+        
+        expect(spy).toHaveBeenCalledTimes(1);
+        
+        spy.mockRestore();
+    });
+
+    it("should throw an error if user creation fails", async () => {
+        mockUserRepository.createUser = jest.fn().mockRejectedValue(new Error("Database error")); 
+
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(null);
+
+        await expect(registerUserUseCase.execute(mockUserData)).rejects.toThrow("Database error");
+    });
+
+    it("should throw an error if required fields are missing", async () => {
+        const invalidData = { ...mockUserData, fullName: "" };
+
+        await expect(registerUserUseCase.execute(invalidData)).rejects.toThrow("All fields are required: fullName, email, and password.");
+    });
+
+    it("should throw an error if email already exists", async () => {
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue({});
+
+        await expect(registerUserUseCase.execute(mockUserData)).rejects.toThrow("User with this email already exists.");
+    });
+
+    it("should encapsulate non-Error exceptions during user creation", async () => {
+        const spy = jest.spyOn(registerUserUseCase, 'validateEmailDoesNotExist')
+            .mockImplementation(() => {
+                throw "Not an Error instance"; // Lançando string
+            });
+        
+        await expect(registerUserUseCase.execute(mockUserData))
+            .rejects
+            .toThrow("Error creating user: Not an Error instance");
+
+        spy.mockRestore();
+    });
+});

--- a/espaco-pratico-api/src/application/use-cases/register-user/register-user.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/register-user/register-user.spec.ts
@@ -13,7 +13,7 @@ const mockUser = {
     _fullName: mockUserData.fullName,
     _email: mockUserData.email,
     _password: mockUserData.password,
-}
+};
 
 const mockUserRepository: IUserRepository = {
     createUser: jest.fn(),
@@ -39,7 +39,7 @@ describe("Validate required fields", () => {
         const userData = {
             ...mockUserData,
             fullName: "",
-        }
+        };
 
         expect(() => registerUserUseCase.validateRequiredFields(userData)).toThrow("All fields are required: fullName, email, and password.");
     });
@@ -48,7 +48,7 @@ describe("Validate required fields", () => {
         const userData = {
             ...mockUserData,
             email: "",
-        }
+        };
 
         expect(() => registerUserUseCase.validateRequiredFields(userData)).toThrow("All fields are required: fullName, email, and password.");
     });
@@ -79,7 +79,7 @@ describe("Validate email does not exist", () => {
 
         expect(mockUserRepository.findUserByEmail).toHaveBeenCalledWith('johndoe@test.com');
     });
-})
+});
 
 describe("Generate user ID", () => {
     it("should generate a valid UUID", () => {
@@ -99,8 +99,8 @@ describe("Generate user ID", () => {
         expect(userId1).not.toBe(userId2);
         expect(userId1).not.toBe(userId3);
         expect(userId2).not.toBe(userId3);
-    })
-})
+    });
+});
 
 describe("Execute use case", () => {
     it("should call repository with correct user object when creating a user", async () => {

--- a/espaco-pratico-api/src/application/use-cases/register-user/register-user.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/register-user/register-user.spec.ts
@@ -1,6 +1,5 @@
 import { RegisterUserUseCase } from "./register-user.use-case";
 import { IUserRepository } from "../../../domain/interfaces/repositories/user-repository.interface";
-import { User } from "../../../domain/entities/userEntity/user.entity";
 
 const mockUserData = {
     fullName: "John Doe",

--- a/espaco-pratico-api/src/application/use-cases/register-user/register-user.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/register-user/register-user.use-case.ts
@@ -1,0 +1,58 @@
+import { IUserRepository } from "../../../domain/interfaces/repositories/user-repository.interface";
+import { User, TUserProperties} from "../../../domain/entities/userEntity/user.entity";
+import { ICreateUserDTO } from "../../dto/create-user.dto";
+import crypto from "crypto";
+
+export class RegisterUserUseCase {
+
+    constructor(private readonly userRepository: IUserRepository) {}
+    
+    async execute(userData: ICreateUserDTO): Promise<User> {
+        try {
+
+            this.validateRequiredFields(userData);
+
+            await this.validateEmailDoesNotExist(userData.email);
+            
+            const userId = this.generateUserId();
+
+            const userProperties: TUserProperties = {
+                id: userId,
+                fullName: userData.fullName,
+                email: userData.email,
+                password: userData.password,
+            };
+
+            const user = new User(userProperties);
+
+            return this.userRepository.createUser(user);
+        }
+        catch (error) {
+
+            if (error instanceof Error) {
+                throw error;
+            }
+            throw new Error(`Error creating user: ${error}`);
+        }
+    }
+
+    validateRequiredFields(userData: ICreateUserDTO): void {
+
+        if (!userData.fullName || !userData.email || !userData.password) {
+            throw new Error("All fields are required: fullName, email, and password.");
+        };
+    }
+
+    async validateEmailDoesNotExist(email: string): Promise<void> {
+
+        const userExists = await this.userRepository.findUserByEmail(email);
+        if (userExists) {
+            throw new Error("User with this email already exists.");
+        }
+    }
+
+    generateUserId(): string {
+
+        return crypto.randomUUID();
+    }
+}


### PR DESCRIPTION
# Descrição

Implementação do caso de uso de registro de usuário no backend, incluindo validações, testes unitários e integração com o repositório de usuários. Este PR adiciona os seguintes componentes:

1. DTO para criação de usuário com campos obrigatórios (nome completo, email, senha)
2. Caso de uso de registro de usuário com validações de campos obrigatórios e verificação de email duplicado
3. Testes unitários abrangentes para validar o funcionamento correto do caso de uso

## Tipo de mudança

- [x] Novo recurso (alteração ininterrupta que adiciona funcionalidade)

## Como isso pode ser testado?

1. Execute os testes unitários do caso de uso com `npm test src/application/use-cases/register-user`
2. Teste a integração manualmente criando um novo usuário através do endpoint de registro (quando implementado)
3. Verifique se todas as validações estão funcionando corretamente:
   - Campos obrigatórios não podem estar vazios
   - Não permite registro com email duplicado
   - IDs são gerados corretamente para novos usuários

## Checklist

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autorevisão do meu próprio código
- [x] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes passam localmente com minhas alterações

Tarefa(s) relacionada(s): "Task 4 - Backend: Create Register User Usecase"