### PR TITLE
Feat/espaço pratico/task 5 backend create login user usecase

### DIFF
--- a/espaco-pratico-api/src/application/dto/login-user.dto.ts
+++ b/espaco-pratico-api/src/application/dto/login-user.dto.ts
@@ -1,0 +1,4 @@
+export interface ILoginUserDTO {
+    email: string;
+    password: string;
+};

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
@@ -21,24 +21,15 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-describe("validateData", () => {
-    it("should not throw an error if email and password are provided", () => {
-        expect(() => loginUserUseCase.validateData(mockData)).not.toThrow();
-    });
-
-    it("should throw an error if email is missing", () => {
-   
-        expect(() => loginUserUseCase.validateData({ ...mockData, email: "" })).toThrow("Email and password are required");
-    });
-
-    it("should throw an error if password is missing", () => {
-   
-        expect(() => loginUserUseCase.validateData({ ...mockData, password: "" })).toThrow("Email and password are required");
-    });
-});
-
 describe("Login", () => {
 
+    it("should throw an errorr if email is missing", async () => {
+        await expect(loginUserUseCase.login({ ...mockData, email: "" })).rejects.toThrow("Email and password are required");
+    });
+
+    it("should throw an error if password is missing", async () => {
+        await expect(loginUserUseCase.login({ ...mockData, password: "" })).rejects.toThrow("Email and password are required");
+    });
 
     it("should return false if user is not found", async () => {
         mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(null);
@@ -65,11 +56,11 @@ describe("Login", () => {
         expect(result).toBe(false);
     });
 
-    it("should call validateData with the correct parameters", () => {
-        const validateDataSpy = jest.spyOn(loginUserUseCase, "validateData");
+    it("should call Login with the correct parameters", () => {
+        const loginSpy = jest.spyOn(loginUserUseCase, "login");
 
         loginUserUseCase.login(mockData);
-        expect(validateDataSpy).toHaveBeenCalledWith(mockData);
+        expect(loginSpy).toHaveBeenCalledWith(mockData);
     });
 
     it("should call confirmEmail with the correct email", async () => {
@@ -77,5 +68,18 @@ describe("Login", () => {
 
         await loginUserUseCase.login(mockData);
         expect(confirmEmailSpy).toHaveBeenCalledWith(mockData.email);
+    });
+
+    it ("should reutrn boolean", async () => {
+        const mockUser = { ...mockData, id: "123" };
+
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(mockUser);
+
+        const result = await loginUserUseCase.login(mockData);
+        expect(typeof result).toBe("boolean");
+    });
+
+    it("should error be the kind of Error", async () => {
+        await expect(loginUserUseCase.login({ ...mockData, email: "" })).rejects.toBeInstanceOf(Error);
     });
 });

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
@@ -8,7 +8,7 @@ const mockData: ILoginUserDTO = {
 };
 
 const mockUserRepository: IUserRepository = {
-    findUserByEmail:jest.fn(),
+    findUserByEmail: jest.fn(),
     createUser: jest.fn(),
     updateUser: jest.fn(),
     deleteUser: jest.fn(),
@@ -23,7 +23,7 @@ beforeEach(() => {
 
 describe("Login", () => {
 
-    it("should throw an errorr if email is missing", async () => {
+    it("should throw an error if email is missing", async () => {
         await expect(loginUserUseCase.login({ ...mockData, email: "" })).rejects.toThrow("Email and password are required");
     });
 
@@ -70,7 +70,7 @@ describe("Login", () => {
         expect(confirmEmailSpy).toHaveBeenCalledWith(mockData.email);
     });
 
-    it ("should reutrn boolean", async () => {
+    it ("should return boolean", async () => {
         const mockUser = { ...mockData, id: "123" };
 
         mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(mockUser);

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
@@ -1,0 +1,81 @@
+import { LoginUserUseCase } from "./login-user.use-case";
+import { IUserRepository } from "../../../domain/interfaces/repositories/user-repository.interface";
+import { ILoginUserDTO } from "../../dto/login-user.dto";
+
+const mockData: ILoginUserDTO = {
+    email: "johndoe@test.com",
+    password:  "Senhaforte123!",
+};
+
+const mockUserRepository: IUserRepository = {
+    findUserByEmail:jest.fn(),
+    createUser: jest.fn(),
+    updateUser: jest.fn(),
+    deleteUser: jest.fn(),
+    findUserById: jest.fn(),
+};
+
+const loginUserUseCase = new LoginUserUseCase(mockUserRepository);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("validateData", () => {
+    it("should not throw an error if email and password are provided", () => {
+        expect(() => loginUserUseCase.validateData(mockData)).not.toThrow();
+    });
+
+    it("should throw an error if email is missing", () => {
+   
+        expect(() => loginUserUseCase.validateData({ ...mockData, email: "" })).toThrow("Email and password are required");
+    });
+
+    it("should throw an error if password is missing", () => {
+   
+        expect(() => loginUserUseCase.validateData({ ...mockData, password: "" })).toThrow("Email and password are required");
+    });
+});
+
+describe("Login", () => {
+
+
+    it("should return false if user is not found", async () => {
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(null);
+
+        const result = await loginUserUseCase.login({...mockData, email: "notexist@email.com"});
+        expect(result).toBe(false);
+    });
+
+    it("should return true if user is found and password matches", async () => {
+        const mockUser = { ...mockData, id: "123" };
+
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(mockUser);
+
+        const result = await loginUserUseCase.login(mockData);
+        expect(result).toBe(true);
+    });
+
+    it("should return false if user is found but password does not match", async () => {
+        const mockUser = { ...mockData, password: "WrongPassword123!", id: "123" };
+
+        mockUserRepository.findUserByEmail = jest.fn().mockResolvedValue(mockUser);
+
+        const result = await loginUserUseCase.login(mockData);
+        expect(result).toBe(false);
+    });
+
+    it("should call validateData with the correct parameters", () => {
+        const validateDataSpy = jest.spyOn(loginUserUseCase, "validateData");
+
+        loginUserUseCase.login(mockData);
+        expect(validateDataSpy).toHaveBeenCalledWith(mockData);
+    });
+
+    it("should call confirmEmail with the correct email", async () => {
+        const confirmEmailSpy = jest.spyOn(mockUserRepository, "findUserByEmail");
+
+        await loginUserUseCase.login(mockData);
+        expect(confirmEmailSpy).toHaveBeenCalledWith(mockData.email);
+    });
+});

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.spec.ts
@@ -63,11 +63,11 @@ describe("Login", () => {
         expect(loginSpy).toHaveBeenCalledWith(mockData);
     });
 
-    it("should call confirmEmail with the correct email", async () => {
-        const confirmEmailSpy = jest.spyOn(mockUserRepository, "findUserByEmail");
+    it("should call findUserByEmail with the correct email", async () => {
+        const findUserByEmail = jest.spyOn(mockUserRepository, "findUserByEmail");
 
         await loginUserUseCase.login(mockData);
-        expect(confirmEmailSpy).toHaveBeenCalledWith(mockData.email);
+        expect(findUserByEmail).toHaveBeenCalledWith(mockData.email);
     });
 
     it ("should return boolean", async () => {

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
@@ -19,7 +19,7 @@ export class LoginUserUseCase {
 
     }
 
-    validateData(data: ILoginUserDTO): void {
+    private validateData(data: ILoginUserDTO): void {
         if (!data.email || !data.password) {
             throw new Error("Email and password are required");
         }

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
@@ -1,0 +1,31 @@
+import { ILoginUserDTO } from "../../dto/login-user.dto";
+import { IUserRepository } from "../../../domain/interfaces/repositories/user-repository.interface";
+import { User } from "../../../domain/entities/userEntity/user.entity";
+
+export class LoginUserUseCase {
+    constructor(private readonly userRepository: IUserRepository) {}
+
+    async login(data: ILoginUserDTO): Promise<boolean> {
+        const { email, password } = data;
+
+        this.validateData(data);
+        const user = await this.confirmEmail(email);
+
+        if (!user) {
+            return false;
+        }
+
+        return password === user.password 
+
+    }
+
+    private validateData(data: ILoginUserDTO): void {
+        if (!data.email || !data.password) {
+            throw new Error("Email and password are required");
+        }
+    }
+
+    private async confirmEmail(email: string): Promise<User | null> {
+        return await this.userRepository.findUserByEmail(email);
+    }
+}

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
@@ -19,7 +19,7 @@ export class LoginUserUseCase {
 
     }
 
-    private validateData(data: ILoginUserDTO): void {
+    validateData(data: ILoginUserDTO): void {
         if (!data.email || !data.password) {
             throw new Error("Email and password are required");
         }

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
@@ -9,7 +9,7 @@ export class LoginUserUseCase {
         const { email, password } = data;
 
         this.validateData(data);
-        const user = await this.findUserByEmail(email);
+        const user = await this.userRepository.findUserByEmail(email);
 
         if (!user) {
             return false;
@@ -23,9 +23,5 @@ export class LoginUserUseCase {
         if (!data.email || !data.password) {
             throw new Error("Email and password are required");
         }
-    }
-
-    private async findUserByEmail(email: string): Promise<User | null> {
-        return await this.userRepository.findUserByEmail(email);
     }
 }

--- a/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/login-user/login-user.use-case.ts
@@ -9,13 +9,13 @@ export class LoginUserUseCase {
         const { email, password } = data;
 
         this.validateData(data);
-        const user = await this.confirmEmail(email);
+        const user = await this.findUserByEmail(email);
 
         if (!user) {
             return false;
         }
 
-        return password === user.password 
+        return password === user.password;
 
     }
 
@@ -25,7 +25,7 @@ export class LoginUserUseCase {
         }
     }
 
-    private async confirmEmail(email: string): Promise<User | null> {
+    private async findUserByEmail(email: string): Promise<User | null> {
         return await this.userRepository.findUserByEmail(email);
     }
 }


### PR DESCRIPTION
# Descrição

Este PR implementa a funcionalidade de login de usuário no backend da aplicação Espaço Prático. A implementação inclui:

- Criação do caso de uso `LoginUserUseCase` para autenticação de usuários
- Implementação de validação de dados de login (email e senha)
- Desenvolvimento de testes unitários abrangentes para garantir o funcionamento correto do caso de uso

## Tipo de mudança

- [x] Novo recurso (alteração ininterrupta que adiciona funcionalidade)

## Como isso pode ser testado?

1. Clone o repositório e navegue até a pasta `espaco-pratico-api`
2. Execute `npm install` para instalar as dependências
3. Execute `npm test` para rodar os testes unitários
4. Para testar manualmente:
   - Inicie o servidor de desenvolvimento
   - Utilize uma ferramenta como Postman ou Insomnia para fazer requisições à rota de login
   - Verifique que o sistema retorna `true` para credenciais válidas e `false` para inválidas

## Checklist

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autorevisão do meu próprio código
- [x] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes passam localmente com minhas alterações

Tarefa(s) relacionada(s): "Task-5-Backend-Create-Login-User-Usecase"