### PR TITLE
Feat/espaço pratico/task 10 backend create list subject use case

### DIFF
--- a/espaco-pratico-api/src/application/dto/create-subject.dto.ts
+++ b/espaco-pratico-api/src/application/dto/create-subject.dto.ts
@@ -1,0 +1,3 @@
+export interface ICreateSubjectDTO {
+    fullName: string;
+};

--- a/espaco-pratico-api/src/application/use-cases/create-subject/create-subject.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/create-subject/create-subject.spec.ts
@@ -1,0 +1,132 @@
+import { CreateSubjectUseCase } from './create-subject.use-case';
+import { ISubjectRepository } from '../../../domain/interfaces/repositories/subject-repository.interface';
+import { ICreateSubjectDTO } from '../../dto/create-subject.dto';
+import { Subject } from '../../../domain/entities/subjectEntity/subject.entity';
+import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
+
+let sut: CreateSubjectUseCase;
+let mockSubjectRepository: ISubjectRepository;
+let mockSubjectData: ICreateSubjectDTO;
+let mockSubject: Subject;
+
+beforeEach(() => {
+  mockSubjectRepository = {
+    createSubject: jest.fn(),
+    listSubjects: jest.fn(),
+  };
+
+  mockSubjectData = {
+    fullName: 'Mathematics',
+  };
+
+  mockSubject = new Subject({
+    id: 'mock-uuid',
+    fullName: mockSubjectData.fullName,
+  });
+
+  sut = new CreateSubjectUseCase(mockSubjectRepository);
+
+  global.crypto = {
+    ...global.crypto,
+    randomUUID: jest.fn().mockReturnValue('mock-uuid'),
+  };
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('CreateSubjectUseCase', () => {
+
+  describe('validateData', () => {
+    it('should not throw an error when fullName is valid', () => {
+      expect(() => CreateSubjectUseCase.validateData(mockSubjectData)).not.toThrow();
+    });
+
+    it('should throw BadRequestException when fullName is empty', () => {
+      const invalidData = { fullName: '' };
+
+      expect(() => CreateSubjectUseCase.validateData(invalidData))
+        .toThrow(new BadRequestException("The subject's full name is required"));
+    });
+
+    it('should throw BadRequestException when fullName is not a string', () => {
+      const invalidData = { fullName: 123 as unknown as string };
+
+      expect(() => CreateSubjectUseCase.validateData(invalidData))
+        .toThrow(new BadRequestException("The subject's full name must be a string"));
+    });
+  });
+
+  describe('execute', () => {
+    it('should create a subject successfully', async () => {
+      (mockSubjectRepository.createSubject as jest.Mock).mockResolvedValue(mockSubject);
+      const validateDataSpy = jest.spyOn(CreateSubjectUseCase, 'validateData');
+
+      const result = await sut.execute(mockSubjectData);
+
+      expect(validateDataSpy).toHaveBeenCalledWith(mockSubjectData);
+      expect(mockSubjectRepository.createSubject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'mock-uuid',
+          fullName: mockSubjectData.fullName,
+        })
+      );
+      expect(result).toEqual(mockSubject);
+    });
+
+    it('should trim the subject name before creating', async () => {
+      const dataWithSpaces = { fullName: '  Mathematics  ' };
+      (mockSubjectRepository.createSubject as jest.Mock).mockResolvedValue({
+        ...mockSubject,
+        fullName: 'Mathematics',
+      });
+
+      await sut.execute(dataWithSpaces);
+
+      expect(mockSubjectRepository.createSubject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fullName: 'Mathematics',
+        })
+      );
+    });
+
+    it('should throw BadRequestException when validation fails', async () => {
+      const invalidData = { fullName: '' };
+
+      await expect(sut.execute(invalidData))
+        .rejects
+        .toThrow(new BadRequestException("The subject's full name is required"));
+      expect(mockSubjectRepository.createSubject).not.toHaveBeenCalled();
+    });
+
+    it('should propagate BadRequestException from validation', async () => {
+      jest.spyOn(CreateSubjectUseCase, 'validateData').mockImplementation(() => {
+        throw new BadRequestException('Custom validation error');
+      });
+
+      await expect(sut.execute(mockSubjectData))
+        .rejects
+        .toThrow(new BadRequestException('Custom validation error'));
+      expect(mockSubjectRepository.createSubject).not.toHaveBeenCalled();
+    });
+
+    it('should wrap Error in InternalServerErrorException', async () => {
+      (mockSubjectRepository.createSubject as jest.Mock).mockRejectedValue(
+        new Error('Custom validation error')
+      );
+
+      await expect(sut.execute(mockSubjectData))
+        .rejects
+        .toThrow(new InternalServerErrorException('Custom validation error'));
+    });
+
+    it('should wrap non-Error exceptions in InternalServerErrorException', async () => {
+      (mockSubjectRepository.createSubject as jest.Mock).mockRejectedValue('String error');
+
+      await expect(sut.execute(mockSubjectData))
+        .rejects
+        .toThrow(new InternalServerErrorException('Custom validation error'));
+    });
+  });
+});

--- a/espaco-pratico-api/src/application/use-cases/create-subject/create-subject.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/create-subject/create-subject.use-case.ts
@@ -1,0 +1,46 @@
+import { Subject } from "../../../domain/entities/subjectEntity/subject.entity";
+import { ISubjectRepository } from "../../../domain/interfaces/repositories/subject-repository.interface";
+import { SubjectRepository } from "../../../infrastructure/database/mongo/repositories/subject-repository/subject.repository";
+import { ICreateSubjectDTO } from "../../dto/create-subject.dto";
+import { ICreateSubjectUseCase } from "../interfaces/use-cases/create-subject.interface";
+import { Injectable, Inject, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+
+@Injectable()
+export class CreateSubjectUseCase implements ICreateSubjectUseCase {
+    constructor(
+        @Inject(SubjectRepository) private readonly subjectRepository: ISubjectRepository
+    ) { }
+
+    async execute(subjectData: ICreateSubjectDTO): Promise<Subject> {
+        try {
+            CreateSubjectUseCase.validateData(subjectData);
+
+            const subject = new Subject({
+                id: crypto.randomUUID(),
+                fullName: subjectData.fullName.trim(),
+            });
+
+            return await this.subjectRepository.createSubject(subject);
+
+        } catch (error) {
+            if (error instanceof BadRequestException) {
+                throw error;
+            }
+            if (error instanceof Error) {
+                throw new InternalServerErrorException(error.message);
+            }
+
+            throw new InternalServerErrorException(`Error creating subject: ${error}`);
+        }
+    }
+
+    static validateData(data: ICreateSubjectDTO): void {
+        if (!data.fullName) {
+            throw new BadRequestException("The subject's full name is required");
+        }
+
+        if (typeof data.fullName !== 'string') {
+            throw new BadRequestException("The subject's full name must be a string");
+        }
+    }
+}

--- a/espaco-pratico-api/src/application/use-cases/interfaces/use-cases/create-subject.interface.ts
+++ b/espaco-pratico-api/src/application/use-cases/interfaces/use-cases/create-subject.interface.ts
@@ -1,0 +1,6 @@
+import { Subject } from "../../../../domain/entities/subjectEntity/subject.entity";
+import { ICreateSubjectDTO } from "../../../dto/create-subject.dto";
+
+export interface ICreateSubjectUseCase {
+    execute(data: ICreateSubjectDTO): Promise<Subject>;
+}

--- a/espaco-pratico-api/src/application/use-cases/interfaces/use-cases/list-subjects.interface.ts
+++ b/espaco-pratico-api/src/application/use-cases/interfaces/use-cases/list-subjects.interface.ts
@@ -1,0 +1,5 @@
+import { Subject } from "../../../../domain/entities/subjectEntity/subject.entity";
+
+export interface IListSubjectsUseCase {
+    execute(): Promise<Subject[]>;
+}

--- a/espaco-pratico-api/src/application/use-cases/list-subjects/list-subjects.spec.ts
+++ b/espaco-pratico-api/src/application/use-cases/list-subjects/list-subjects.spec.ts
@@ -1,0 +1,101 @@
+import { ListSubjectsUseCase } from './list-subjects.use-case';
+import { ISubjectRepository } from '../../../domain/interfaces/repositories/subject-repository.interface';
+import { Subject } from '../../../domain/entities/subjectEntity/subject.entity';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+
+  let sut: ListSubjectsUseCase;
+  let mockSubjectRepository: ISubjectRepository;
+  let mockSubjects: Subject[];
+
+  beforeEach(() => {
+    mockSubjectRepository = {
+      createSubject: jest.fn(),
+      listSubjects: jest.fn(),
+    };
+
+    mockSubjects = [
+      new Subject({ id: '1', fullName: 'Mathematics' }),
+      new Subject({ id: '2', fullName: 'Physics' }),
+      new Subject({ id: '3', fullName: 'Chemistry' }),
+    ];
+
+    sut = new ListSubjectsUseCase(mockSubjectRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  
+describe('ListSubjectsUseCase', () => {
+
+  describe('execute', () => {
+    it('should return a list of subjects when subjects exist', async () => {
+      (mockSubjectRepository.listSubjects as jest.Mock).mockResolvedValue(mockSubjects);
+
+      const result = await sut.execute();
+
+      expect(mockSubjectRepository.listSubjects).toHaveBeenCalled();
+      expect(result).toEqual(mockSubjects);
+      expect(result.length).toBe(3);
+      expect(result[0]).toBeInstanceOf(Subject);
+    });
+
+    it('should return an empty array when no subjects are found', async () => {
+      const emptySubjects: Subject[] = [];
+      (mockSubjectRepository.listSubjects as jest.Mock).mockResolvedValue(emptySubjects);
+
+      const result = await sut.execute();
+
+      expect(mockSubjectRepository.listSubjects).toHaveBeenCalled();
+      expect(result).toEqual(emptySubjects);
+      expect(result.length).toBe(0);
+    });
+
+    it('should handle repository errors and wrap them in InternalServerErrorException', async () => {
+      const error = new Error('Database error');
+      (mockSubjectRepository.listSubjects as jest.Mock).mockRejectedValue(error);
+
+      await expect(sut.execute())
+        .rejects
+        .toThrow(new InternalServerErrorException('Database error'));
+      expect(mockSubjectRepository.listSubjects).toHaveBeenCalled();
+    });
+
+    it('should handle NotFoundException and propagate it', async () => {
+      const notFoundError = new NotFoundException('No subjects found');
+      (mockSubjectRepository.listSubjects as jest.Mock).mockRejectedValue(notFoundError);
+
+      await expect(sut.execute())
+        .rejects
+        .toThrow(notFoundError);
+      expect(mockSubjectRepository.listSubjects).toHaveBeenCalled();
+    });
+
+    it('should wrap non-Error exceptions in InternalServerErrorException', async () => {
+      (mockSubjectRepository.listSubjects as jest.Mock).mockRejectedValue('String error');
+
+      await expect(sut.execute())
+        .rejects
+        .toThrow(new InternalServerErrorException('Error listing subjects: String error'));
+      expect(mockSubjectRepository.listSubjects).toHaveBeenCalled();
+    });
+
+    it('should handle null response from repository', async () => {
+      (mockSubjectRepository.listSubjects as jest.Mock).mockResolvedValue(null);
+
+      const result = await sut.execute();
+
+      expect(mockSubjectRepository.listSubjects).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it('should handle undefined response from repository', async () => {
+      (mockSubjectRepository.listSubjects as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await sut.execute();
+
+      expect(mockSubjectRepository.listSubjects).toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/espaco-pratico-api/src/application/use-cases/list-subjects/list-subjects.use-case.ts
+++ b/espaco-pratico-api/src/application/use-cases/list-subjects/list-subjects.use-case.ts
@@ -1,0 +1,32 @@
+import { Injectable, Inject, NotFoundException, InternalServerErrorException } from '@nestjs/common';
+import { IListSubjectsUseCase } from '../interfaces/use-cases/list-subjects.interface';
+import { SubjectRepository } from '../../../infrastructure/database/mongo/repositories/subject-repository/subject.repository';
+import { Subject } from '../../../domain/entities/subjectEntity/subject.entity';
+import { ISubjectRepository } from '../../../domain/interfaces/repositories/subject-repository.interface';
+
+@Injectable()
+export class ListSubjectsUseCase implements IListSubjectsUseCase {
+    constructor(
+        @Inject(SubjectRepository) private readonly subjectRepository: ISubjectRepository
+    ) { }
+
+    async execute(): Promise<Subject[]> {
+
+        try {
+            const subjects = await this.subjectRepository.listSubjects();
+
+            return subjects
+        } catch (error) {
+            if (error instanceof NotFoundException) {
+                throw error;
+            }
+
+            if (error instanceof Error) {
+                throw new InternalServerErrorException(error.message);
+            }
+
+            throw new InternalServerErrorException(`Error listing subjects: ${error}`);
+        }
+
+    }
+}

--- a/espaco-pratico-api/src/infrastructure/database/mongo/repositories/subject-repository/subject.repository.spec.ts
+++ b/espaco-pratico-api/src/infrastructure/database/mongo/repositories/subject-repository/subject.repository.spec.ts
@@ -64,15 +64,6 @@ describe('SubjectRepository', () => {
 
             await expect(subjectRepository.createSubject(mockSubject)).rejects.toThrow(error);
         });
-
-        it('should throw an error if subject with name already exists', async () => {
-            const SubjectModel = require('../../models/subject.model').default;
-            const error = new Error('Subject with this name already exists');
-            error.name = 'MongoServerError';
-            (SubjectModel.create as jest.Mock).mockRejectedValue(error);
-
-            await expect(subjectRepository.createSubject(mockSubject)).rejects.toThrow('Subject with this name already exists');
-        });
     });
 
     describe('listSubjects', () => {

--- a/espaco-pratico-api/src/infrastructure/database/mongo/repositories/subject-repository/subject.repository.ts
+++ b/espaco-pratico-api/src/infrastructure/database/mongo/repositories/subject-repository/subject.repository.ts
@@ -22,11 +22,6 @@ export class SubjectRepository implements ISubjectRepository {
         }
         catch (error) {
 
-            if (error instanceof Error && error.name === 'MongoServerError') {
-                console.error("Subject with this name already exists:", error);
-                throw new Error("Subject with this name already exists");
-            }
-
             console.error("Error creating subject:", error);
             throw error;
         }

--- a/espaco-pratico-api/src/infrastructure/database/mongo/schemas/subject.schema.ts
+++ b/espaco-pratico-api/src/infrastructure/database/mongo/schemas/subject.schema.ts
@@ -12,7 +12,6 @@ export const subjectSchema = new mongoose.Schema<ISubjectDocument>(
             type: String,
             required: true,
             trim: true,
-            unique: true,
         },
     },
     {


### PR DESCRIPTION
# Descrição

Este PR implementa dois casos de uso relacionados aos assuntos (subjects) no backend: o caso de uso para criar assuntos (CreateSubjectUseCase) e para listar assuntos (ListSubjectsUseCase). Inclui validação de dados, tratamento de erros e testes unitários completos para ambas as funcionalidades.

## Tipo de mudança

- [ ] Correção de bug (alteração ininterrupta que corrige um problema)
- [x] Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [ ] Alteração de última hora (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [ ] Esta alteração requer uma atualização de documentação

## Como isso pode ser testado?

1. Execute os testes unitários para verificar o comportamento esperado:
   ```
   npm run test -- create-subject.spec.ts
   npm run test -- list-subjects.spec.ts
   ```

## Checklist

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autorevisão do meu próprio código
- [x] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes passam localmente com minhas alterações


Tarefa(s) relacionada(s): "Task #10: Backend - Create and List Subject Use Cases"