### PR TITLE
Feat/espaço pratico/task 11 backend create subjects controller

### DIFF
--- a/espaco-pratico-api/src/interfaces/http/controllers/subject/subject.controller.spec.ts
+++ b/espaco-pratico-api/src/interfaces/http/controllers/subject/subject.controller.spec.ts
@@ -1,0 +1,185 @@
+import { SubjectController } from './subject.controller';
+import { ListSubjectsUseCase } from '../../../../application/use-cases/list-subjects/list-subjects.use-case';
+import { CreateSubjectUseCase } from '../../../../application/use-cases/create-subject/create-subject.use-case';
+import { Subject } from '../../../../domain/entities/subjectEntity/subject.entity';
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+let sut: SubjectController;
+let mockListSubjectsUseCase: jest.Mocked<ListSubjectsUseCase>;
+let mockCreateSubjectUseCase: jest.Mocked<CreateSubjectUseCase>;
+let mockSubject: Subject;
+
+beforeEach(() => {
+  // Arrange - Setup mocks
+  mockListSubjectsUseCase = {
+    execute: jest.fn(),
+  } as unknown as jest.Mocked<ListSubjectsUseCase>;
+
+  mockCreateSubjectUseCase = {
+    execute: jest.fn(),
+  } as unknown as jest.Mocked<CreateSubjectUseCase>;
+
+  mockSubject = new Subject({
+    id: 'mock-id',
+    fullName: 'Mathematics',
+  });
+
+  // Create the controller with mocked dependencies
+  sut = new SubjectController(
+    mockListSubjectsUseCase,
+    mockCreateSubjectUseCase,
+  );
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('SubjectController', () => {
+
+  describe('create', () => {
+    it('should create a subject successfully and return correct response', async () => {
+      const subjectData = { fullName: 'Mathematics' };
+      mockCreateSubjectUseCase.execute.mockResolvedValue(mockSubject);
+
+      const result = await sut.create(subjectData);
+
+      expect(mockCreateSubjectUseCase.execute).toHaveBeenCalledWith(subjectData);
+      expect(result).toEqual({
+        statusCode: HttpStatus.CREATED,
+        message: 'Subject created successfully',
+        data: mockSubject,
+      });
+    });
+
+    it('should handle errors from CreateSubjectUseCase and throw HttpException', async () => {
+      const subjectData = { fullName: 'Mathematics' };
+      const error = new Error('Subject creation failed');
+      mockCreateSubjectUseCase.execute.mockRejectedValue(error);
+
+      await expect(sut.create(subjectData)).rejects.toThrow(HttpException);
+      expect(mockCreateSubjectUseCase.execute).toHaveBeenCalledWith(subjectData);
+    });
+
+    it('should propagate HttpException from CreateSubjectUseCase', async () => {
+      const subjectData = { fullName: 'Mathematics' };
+      const httpException = new HttpException(
+        'Custom HTTP exception',
+        HttpStatus.BAD_REQUEST,
+      );
+      mockCreateSubjectUseCase.execute.mockRejectedValue(httpException);
+
+      await expect(sut.create(subjectData)).rejects.toBe(httpException);
+      expect(mockCreateSubjectUseCase.execute).toHaveBeenCalledWith(subjectData);
+    });
+
+    it('should handle non-Error exceptions and wrap them in HttpException', async () => {
+      const subjectData = { fullName: 'Mathematics' };
+      mockCreateSubjectUseCase.execute.mockRejectedValue('String error');
+
+      await expect(sut.create(subjectData)).rejects.toThrow(HttpException);
+      expect(mockCreateSubjectUseCase.execute).toHaveBeenCalledWith(subjectData);
+    });
+  });
+
+  describe('list', () => {
+    it('should return a list of subjects successfully', async () => {
+      const mockSubjects = [mockSubject, mockSubject];
+      mockListSubjectsUseCase.execute.mockResolvedValue(mockSubjects);
+
+      const result = await sut.list();
+
+      expect(mockListSubjectsUseCase.execute).toHaveBeenCalled();
+      expect(result).toEqual(mockSubjects);
+      expect(result.length).toBe(2);
+    });
+
+    it('should return an empty array when no subjects are found', async () => {
+      const emptySubjects: Subject[] = [];
+      mockListSubjectsUseCase.execute.mockResolvedValue(emptySubjects);
+
+      const result = await sut.list();
+
+      expect(mockListSubjectsUseCase.execute).toHaveBeenCalled();
+      expect(result).toEqual(emptySubjects);
+      expect(result.length).toBe(0);
+    });
+
+    it('should handle errors from ListSubjectsUseCase and throw HttpException', async () => {
+      const error = new Error('Failed to list subjects');
+      mockListSubjectsUseCase.execute.mockRejectedValue(error);
+
+      await expect(sut.list()).rejects.toThrow(HttpException);
+      expect(mockListSubjectsUseCase.execute).toHaveBeenCalled();
+    });
+
+    it('should propagate HttpException from ListSubjectsUseCase', async () => {
+      const httpException = new HttpException(
+        'Custom HTTP exception',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      mockListSubjectsUseCase.execute.mockRejectedValue(httpException);
+
+      await expect(sut.list()).rejects.toBe(httpException);
+      expect(mockListSubjectsUseCase.execute).toHaveBeenCalled();
+    });
+
+    it('should handle non-Error exceptions and wrap them in HttpException', async () => {
+      mockListSubjectsUseCase.execute.mockRejectedValue('String error');
+
+      await expect(sut.list()).rejects.toThrow(HttpException);
+      expect(mockListSubjectsUseCase.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleError', () => {
+    it('should propagate HttpException without modification', async () => {
+      const httpException = new HttpException(
+        'Original exception',
+        HttpStatus.BAD_REQUEST,
+      );
+      mockCreateSubjectUseCase.execute.mockRejectedValue(httpException);
+
+      await expect(sut.create({ fullName: 'Test' })).rejects.toBe(httpException);
+    });
+
+    it('should wrap Error in HttpException with provided status code', async () => {
+      const error = new Error('Test error');
+      mockCreateSubjectUseCase.execute.mockRejectedValue(error);
+
+      try {
+        await sut.create({ fullName: 'Test' });
+        fail('Expected exception was not thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(HttpException);
+
+        if (e instanceof HttpException) {
+          expect(e.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+          expect(e.getResponse()).toEqual({
+            statusCode: HttpStatus.BAD_REQUEST,
+            message: 'Test error',
+          });
+        }
+      }
+    });
+
+    it('should wrap non-Error exceptions in HttpException with INTERNAL_SERVER_ERROR', async () => {
+      mockCreateSubjectUseCase.execute.mockRejectedValue('Not an error');
+
+      try {
+        await sut.create({ fullName: 'Test' });
+        fail('Expected exception was not thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(HttpException);
+
+        if (e instanceof HttpException) {
+          expect(e.getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+          expect(e.getResponse()).toEqual({
+            statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+            message: 'An unexpected error occurred.',
+          });
+        }
+      }
+    });
+  });
+});

--- a/espaco-pratico-api/src/interfaces/http/controllers/subject/subject.controller.ts
+++ b/espaco-pratico-api/src/interfaces/http/controllers/subject/subject.controller.ts
@@ -1,0 +1,63 @@
+import { ListSubjectsUseCase } from "../../../../application/use-cases/list-subjects/list-subjects.use-case";
+import { CreateSubjectUseCase } from "../../../../application/use-cases/create-subject/create-subject.use-case";
+import { Inject, Controller, Post, Body, Get, HttpException, HttpStatus } from "@nestjs/common";
+import { Subject } from "../../../../domain/entities/subjectEntity/subject.entity";
+import { TCreateSubjectResponse } from "../../interfaces/api.response.interface";
+
+@Controller('subjects')
+export class SubjectController {
+
+    constructor(
+        @Inject(ListSubjectsUseCase)
+        private readonly listSubjectsUseCase: ListSubjectsUseCase,
+
+        @Inject(CreateSubjectUseCase)
+        private readonly createSubjectUseCase: CreateSubjectUseCase
+    ) { }
+
+    @Post('create')
+    async create(@Body() subjectData: { fullName: string }): Promise<TCreateSubjectResponse> {
+        try {
+            const subject = await this.createSubjectUseCase.execute(subjectData);
+
+            return {
+                statusCode: HttpStatus.CREATED,
+                message: 'Subject created successfully',
+                data: subject as Subject
+            };
+        } catch (error) {
+            this.handleError(error, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Get('list')
+    async list(): Promise<Subject[]> {
+        try {
+            return await this.listSubjectsUseCase.execute();
+        } catch (error) {
+            this.handleError(error, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private handleError(error: unknown, statusCode: HttpStatus): never {
+        if (error instanceof HttpException) {
+            throw error;
+        }
+
+        if (error instanceof Error) {
+            throw new HttpException({
+                statusCode: statusCode,
+                message: error.message,
+            },
+                statusCode
+            );
+        }
+
+        throw new HttpException({
+            statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+            message: "An unexpected error occurred."
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+
+    }
+
+}

--- a/espaco-pratico-api/src/interfaces/http/http.module.ts
+++ b/espaco-pratico-api/src/interfaces/http/http.module.ts
@@ -6,10 +6,15 @@ import { RegisterUserUseCase } from '../../application/use-cases/register-user/r
 import { UserRepository } from '../../infrastructure/database/mongo/repositories/user-repository/user.repository';
 import { MongooseModule } from '@nestjs/mongoose';
 import { userSchema } from '../../infrastructure/database/mongo/schemas/user.schema';
+import { SubjectController } from './controllers/subject/subject.controller';
+import { SubjectRepository } from '../../infrastructure/database/mongo/repositories/subject-repository/subject.repository';
+import { subjectSchema } from '../../infrastructure/database/mongo/schemas/subject.schema';
+import { CreateSubjectUseCase } from '../../application/use-cases/create-subject/create-subject.use-case';
+import { ListSubjectsUseCase } from '../../application/use-cases/list-subjects/list-subjects.use-case';
 
 @Module({
-  controllers: [AppController, UserController],
-  providers: [LoginUserUseCase, RegisterUserUseCase, UserRepository],
-  imports: [MongooseModule.forFeature([{ name: 'User', schema: userSchema }])],
+  controllers: [AppController, UserController, SubjectController],
+  providers: [LoginUserUseCase, RegisterUserUseCase, UserRepository, SubjectRepository, CreateSubjectUseCase, ListSubjectsUseCase],
+  imports: [MongooseModule.forFeature([{ name: 'User', schema: userSchema }, { name: 'Subject', schema: subjectSchema }])],
 })
-export class HttpModule {}
+export class HttpModule { }

--- a/espaco-pratico-api/src/interfaces/http/interfaces/api.response.interface.ts
+++ b/espaco-pratico-api/src/interfaces/http/interfaces/api.response.interface.ts
@@ -8,7 +8,10 @@ export interface IRegisterResponseData {
     fullName: string;
     email: string;
 }
-
+export interface ICreateSubjectDTO {
+    id: string;
+    fullName: string;
+}
 export type TRegisterResponse = IApiResponse<IRegisterResponseData>;
 export type TLoginResponse = IApiResponse<null>;
-
+export type TCreateSubjectResponse = IApiResponse<ICreateSubjectDTO>;


### PR DESCRIPTION
# Descrição

Este PR implementa o novo controlador de disciplinas (SubjectController) com endpoints para criação e listagem de disciplinas, além de configurar o tratamento adequado de erros. A implementação inclui testes unitários completos para garantir que todas as funcionalidades estão operando corretamente.

## Tipo de mudança

- [x] Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [ ] Correção de bug (alteração ininterrupta que corrige um problema)
- [ ] Alteração de última hora (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [ ] Esta alteração requer uma atualização de documentação

## Como isso pode ser testado?

1. Execute os testes unitários para o controlador de disciplinas usando:
   ```bash
   npm test src/interfaces/http/controllers/subject/subject.controller.spec.ts
   ```

2. Teste o endpoint de criação de disciplina:
   ```bash
   curl -X POST http://localhost:3000/subjects/create -H "Content-Type: application/json" -d '{"fullName": "Mathematics"}'
   ```

3. Teste o endpoint de listagem de disciplinas:
   ```bash
   curl -X GET http://localhost:3000/subjects/list
   ```

## Checklist

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autorevisão do meu próprio código
- [x] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes passam localmente com minhas alterações

Tarefa(s) relacionada(s): "Task 11 - Backend - Create Subjects Controller"